### PR TITLE
Added scope test for junit in pom.xml

### DIFF
--- a/tsne-core/pom.xml
+++ b/tsne-core/pom.xml
@@ -39,6 +39,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.fommil.netlib</groupId>


### PR DESCRIPTION
Junit should not be needed in generated artifact. Not sure if this screws up your tests, but it helps with transitive hell for those depending on your project.